### PR TITLE
Add calibration features to web ui

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,8 +1,10 @@
 var device = 0;
 ko_value = ko.observable(0);
 let decoder = new TextDecoder('utf-8');
+let encoder = new TextEncoder('utf-8');
 
 var app = {
+  service: 0,
   value: 0,
   characteristic: 0,
   ko_value: ko.observable('-'),
@@ -10,6 +12,8 @@ var app = {
   ko_temp: ko.observable('-'),
   ko_temp_unit: ko.observable('-'),
   ko_name: ko.observable(''),
+  ko_low_ref: ko.observable('4.01'),
+  ko_high_ref: ko.observable('7.01'),
   connected: ko.observable(false),
   initialize: async function() {
 
@@ -32,7 +36,7 @@ var app = {
         const server = await device.gatt.connect();
         app.connected(true);
 
-        const service = await server.getPrimaryService(serviceUuid);
+        service = await server.getPrimaryService(serviceUuid);
         characteristic = await service.getCharacteristic(characteristicUuid);
 
         value = await characteristic.readValue().then(value => {
@@ -81,5 +85,17 @@ var app = {
   temp_update: async function(event) {
     let value = event.target.value;
     app.ko_temp(decoder.decode(value));
+  },
+  calibrateHighRef: async function() {
+    let highRef = '1dadca6b-3ecc-41bd-a116-f77248975310';
+    console.log("Calibrating high ref: " + app.ko_high_ref());
+    var characteristic = await service.getCharacteristic(highRef);
+    characteristic.writeValue(encoder.encode(app.ko_high_ref()));
+  },
+  calibrateLowRef: async function() {
+    let lowRef = '1baa566e-4657-4080-a580-d236af1c6bd9';
+    console.log("Calibrating low ref: " + app.ko_low_ref());
+    var characteristic = await service.getCharacteristic(lowRef);
+    characteristic.writeValue(encoder.encode(app.ko_low_ref()));
   }
 };

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,24 @@
                       <p class='subtitle' data-bind='text: app.ko_temp_unit'>C</p>
                     </div>
                   </div>
+                  <div class='card has-text-centered' data-bind="visible: app.connected">
+                    <div class='card-content'>
+                      <p class='title'>Low Ref</p>
+                      <p class='subtitle'>
+                        <input type="text" data-bind="textInput: app.ko_low_ref" />
+                        <button data-bind="click: app.calibrateLowRef">Calibrate</button>
+                      </p>
+                    </div>
+                  </div>
+                  <div class='card has-text-centered' data-bind="visible: app.connected">
+                    <div class='card-content'>
+                      <p class='title'>High Ref</p>
+                      <p class='subtitle'>
+                        <input type="text" data-bind="textInput: app.ko_high_ref" />
+                        <button data-bind="click: app.calibrateHighRef">Calibrate</button>
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,14 @@
                       </p>
                     </div>
                   </div>
+                  <div data-bind="foreach: app.ko_bools">
+                    <div class='card has-text-centered'>
+                      <div class='card-content'>
+                        <p class='title' data-bind='text: description'></p>
+                        <p class='subtitle'><input type="checkbox" data-bind="checked: value" /></p>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
In order to evaluate the ISE interface, I needed to calibrate the pH probe. This seemed like a useful feature to add to the still basic web ui, as now getting started is possible without writing any code.

The starting reference values are specific to pH, but I'm not sure what to do about that, given that reading these back on initialization doesn't seem to return anything useful.